### PR TITLE
Add configuration for travis-ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: false
+language: erlang
+addons:
+  apt:
+    packages:
+      - xsltproc
+otp_release:
+  - R16B03-1
+  - 17.5
+  - 18.0
+install:
+  - if [ ! -d "$HOME/rabbitmq-public-umbrella/.git" ]; then git clone https://github.com/rabbitmq/rabbitmq-public-umbrella.git $HOME/rabbitmq-public-umbrella; fi
+  - cd $HOME/rabbitmq-public-umbrella
+  - make co
+  - make up
+before_script:
+  - IFS="/" read -a PARTS <<< "$TRAVIS_REPO_SLUG"
+  - export TEST_DIR=$HOME/rabbitmq-public-umbrella/${PARTS[1]}
+  - rm -rf ${TEST_DIR}
+  - cp -r ${TRAVIS_BUILD_DIR} ${TEST_DIR}
+  - cd ${TEST_DIR}
+script: make test
+before_cache:
+  - rm -rf ${TEST_DIR}
+  - cd $HOME
+cache:
+  apt: true
+  directories:
+    - $HOME/rabbitmq-public-umbrella


### PR DESCRIPTION
This PR adds support for travis-ci with a generic ``.travis.yaml`` that can be added to all projects that live under [rabbitmq/rabbitmq-public-umbrella](https://github.com/rabbitmq/rabbitmq-public-umbrella).

The tests run against Erlang R16B03-1, 17.5, and 18.0.

It does not test in the ``$TRAVIS_BUILD_DIR`` because it needs to setup the public umbrella and run the test in the appropriate subdirectory. To achieve this it goes a git clone of the umbrella, removes the pre-existing directory from the umbrella ``make co`` command, and copies in ``$TRAVIS_BUILD_DIR`` to the appropriate place before running ``make test``.

It also caches the public-umbrella checkout for faster subsequent tests.

You'll need to enable travis for this to work, which you won't see on this PR. Here's a [link to my repo's tests on Travis](https://travis-ci.org/gmr/rabbitmq-consistent-hash-exchange/builds/76710847)
Let me know if you have any questions.