### PR TITLE
Make exchange consistent across restarts

### DIFF
--- a/src/rabbit_exchange_type_consistent_hash.erl
+++ b/src/rabbit_exchange_type_consistent_hash.erl
@@ -144,7 +144,7 @@ add_binding(transaction, _X,
                                #bucket { source_number = {S, N},
                                          destination   = D,
                                          binding       = B },
-                               write) || N <- find_numbers(S, BucketCount, [])],
+                               write) || N <- find_numbers(S, D, BucketCount, [])],
             ok;
         _ ->
             ok
@@ -176,14 +176,12 @@ init() ->
     mnesia:wait_for_tables([?TABLE], 30000),
     ok.
 
-find_numbers(_Source, 0, Acc) ->
+find_numbers(_Source, _Destination, 0, Acc) ->
     Acc;
-find_numbers(Source, N, Acc) ->
-    Number = rand_compat:uniform(?PHASH2_RANGE) - 1,
-    case mnesia:read(?TABLE, {Source, Number}, write) of
-        []  -> find_numbers(Source, N-1, [Number | Acc]);
-        [_] -> find_numbers(Source, N, Acc)
-    end.
+find_numbers(Source, Destination, N, Acc) ->
+    Term = {Source, Destination, N},
+    Number = erlang:phash2(Term, ?PHASH2_RANGE),
+    find_numbers(Source, Destination, N-1, [Number | Acc]).
 
 hash(undefined, #basic_message { routing_keys = Routes }) ->
     Routes;


### PR DESCRIPTION
The message hash used to be compared to a random number to choose the
destination. This random number would change when the broker restarts, making
the exchange not consistent across restarts. This commit replaces
the random number by a hash based on the source and the destination,
which is the same across restarts.

Fixes #32