### PR TITLE
Correctly determine bucket range boundaries when updating hash ring state

### DIFF
--- a/src/rabbit_exchange_type_consistent_hash.erl
+++ b/src/rabbit_exchange_type_consistent_hash.erl
@@ -195,11 +195,11 @@ remove_binding(#binding{source = S, destination = D, key = RK}) ->
             case maps:size(BucketsOfThisBinding) of
                 0             -> ok;
                 N when N >= 1 ->
-                    KeysOfThisBinding  = maps:keys(BucketsOfThisBinding),
+                    KeysOfThisBinding  = lists:usort(maps:keys(BucketsOfThisBinding)),
                     LastBucket         = lists:last(KeysOfThisBinding),
                     FirstBucket        = hd(KeysOfThisBinding),
                     BucketsDownTheRing = maps:filter(fun (K, _) -> K > LastBucket end, BM0),
-                    UnchangedBuckets = maps:filter(fun (K, _) -> K < FirstBucket end, BM0),
+                    UnchangedBuckets   = maps:filter(fun (K, _) -> K < FirstBucket end, BM0),
 
                     %% final state with "down the ring" buckets updated
                     NewBucketsDownTheRing = maps:fold(


### PR DESCRIPTION
## Proposed Changes

When a binding was removed, its bucket range boundaries were not deterministically determined
since a piece of code relied on bucket ordering. With a small number of buckets/small hash ring state map this seemed to work fine in practice but as @lukas-phaf discovered and reported in #40,
greater values eventually stumble upon incorrect ordering, which leads to an inconsistent hash ring state.

Per discussion with @dcorbacho.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #40)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #40.
