### PR TITLE
wait_for_confirms timeout is in seconds

### DIFF
--- a/test/rabbit_exchange_type_consistent_hash_SUITE.erl
+++ b/test/rabbit_exchange_type_consistent_hash_SUITE.erl
@@ -228,7 +228,7 @@ test0(Config, MakeMethod, MakeMsg, DeclareArgs, [Q1, Q2, Q3, Q4] = Queues, Itera
     [amqp_channel:call(Chan,
                        MakeMethod(CHX),
                        MakeMsg()) || _ <- lists:duplicate(IterationCount, const)],
-    amqp_channel:wait_for_confirms(Chan, 5000),
+    amqp_channel:wait_for_confirms(Chan, 5),
     timer:sleep(500),
 
     Counts =


### PR DESCRIPTION
References rabbitmq/rabbitmq-erlang-client#138

cc @dumbbell